### PR TITLE
Use OS-specific dictionary path in setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 # Makefile Tip 1: Escape $ with $$ 
 # https://stackoverflow.com/questions/2382764/escaping-in-makefile
 
+# Detect the operating system to use the appropriate dictionary file
+OS := $(shell uname)
+DICT := /usr/share/dict/american-english
+ifeq ($(OS),Darwin)
+        DICT := /usr/share/dict/words
+endif
+
 setup:
-	cat /usr/share/dict/american-english | grep -E '^[A-Za-z]{5}$$' | awk '{print toupper($$0)}' > dict5.txt
+	cat $(DICT) | grep -E '^[A-Za-z]{5}$$' | awk '{print toupper($$0)}' > dict5.txt
 
 play:
 	./play-wordle.sh


### PR DESCRIPTION
## Summary
- Detect operating system in Makefile to pick correct dictionary
- Use `/usr/share/dict/words` on macOS and `/usr/share/dict/american-english` otherwise

## Testing
- `make unit-test`
- `make shellcheck` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a74684679c832f86c253c550c2862d